### PR TITLE
Implement dashboard bot manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ cd BotFury
    ```
 2. Start the Flask server:
    ```bash
+   cd flask-dashboard
    python3 dashboard.py
    ```
 3. Open `http://localhost:5000` in your browser.
@@ -64,9 +65,10 @@ cd BotFury
 ---
 
 ## 🔧 How to Use
-1. **Launch Multiple Bots**  
+1. **Launch Multiple Bots**
    - Use the Flask web dashboard to start multiple bot instances.
-   - Assign randomized names or manually set them.
+   - Assign randomized names or manually set them. The included Python example
+     spawns lightweight dummy bots to demonstrate the workflow.
   
 2. **Connect to a Minecraft Server**  
    - Select a server IP from the dashboard and press “Connect.”

--- a/flask-dashboard/bot_manager.py
+++ b/flask-dashboard/bot_manager.py
@@ -1,0 +1,67 @@
+import subprocess
+import os
+from typing import Dict, Optional
+
+class BotProcess:
+    def __init__(self, bot_id: int, server_ip: str):
+        self.bot_id = bot_id
+        self.server_ip = server_ip
+        self.process: Optional[subprocess.Popen] = None
+
+    def start(self):
+        if self.process and self.process.poll() is None:
+            return False
+        cmd = ["python3", os.path.join(os.path.dirname(__file__), "dummy_bot.py"),
+               "--bot_id", str(self.bot_id), "--server_ip", self.server_ip]
+        self.process = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        return True
+
+    def stop(self):
+        if self.process and self.process.poll() is None:
+            try:
+                self.process.stdin.write("stop\n")
+                self.process.stdin.flush()
+                self.process.wait(timeout=5)
+            except Exception:
+                self.process.terminate()
+        self.process = None
+
+    def send_command(self, command: str):
+        if self.process and self.process.poll() is None:
+            try:
+                self.process.stdin.write(command + "\n")
+                self.process.stdin.flush()
+            except Exception:
+                pass
+
+class BotManager:
+    def __init__(self):
+        self.bots: Dict[int, BotProcess] = {}
+
+    def start_bot(self, bot_id: int, server_ip: str):
+        bot = self.bots.get(bot_id)
+        if not bot:
+            bot = BotProcess(bot_id, server_ip)
+            self.bots[bot_id] = bot
+        else:
+            bot.server_ip = server_ip
+        return bot.start()
+
+    def stop_bot(self, bot_id: int):
+        bot = self.bots.get(bot_id)
+        if bot:
+            bot.stop()
+
+    def send_command(self, bot_id: int, command: str):
+        bot = self.bots.get(bot_id)
+        if bot:
+            bot.send_command(command)
+
+    def toggle_render(self):
+        for bot in self.bots.values():
+            bot.send_command("toggle_render")
+
+    def broadcast_chat(self, message: str):
+        for bot in self.bots.values():
+            bot.send_command(f"chat {message}")
+

--- a/flask-dashboard/dashboard.py
+++ b/flask-dashboard/dashboard.py
@@ -1,7 +1,9 @@
 from flask import Flask, render_template, request, jsonify
 import requests
+from bot_manager import BotManager
 
 app = Flask(__name__)
+bot_manager = BotManager()
 
 # Your Discord webhook URL – all commands will be sent here
 DISCORD_WEBHOOK_URL = "https://discord.com/api/webhooks/1345709743922216970/BYZQCnPjRNzimDEak3f0HsV1OOvSOta0dPYl6LYStye87Ty4ULUkemEv0_nPNN42GpmV"
@@ -16,9 +18,9 @@ def send_discord_webhook(message):
 
 # Dummy data for bot list (will be used only for display)
 bots = [
-    {"id": 1, "name": "Bot01", "status": "Unknown"},
-    {"id": 2, "name": "Bot02", "status": "Unknown"},
-    {"id": 3, "name": "Bot03", "status": "Unknown"},
+    {"id": 1, "name": "Bot01", "status": "Stopped"},
+    {"id": 2, "name": "Bot02", "status": "Stopped"},
+    {"id": 3, "name": "Bot03", "status": "Stopped"},
 ]
 
 # Dummy server IP (for display)
@@ -37,39 +39,42 @@ def send_webhook():
 @app.route("/start_bot", methods=["POST"])
 def start_bot():
     bot_id = request.json.get("bot_id")
-    # Construct a command message for starting a bot
-    command = f"start_bot {bot_id}"
-    send_discord_webhook(command)
-    return jsonify({"status": f"Start command for Bot {bot_id} sent via webhook"})
+    if bot_manager.start_bot(bot_id, server_ip):
+        bots[bot_id - 1]["status"] = "Running"
+        send_discord_webhook(f"start_bot {bot_id}")
+        status = f"Bot {bot_id} started"
+    else:
+        status = f"Bot {bot_id} already running"
+    return jsonify({"status": status})
 
 @app.route("/stop_bot", methods=["POST"])
 def stop_bot():
     bot_id = request.json.get("bot_id")
-    command = f"stop_bot {bot_id}"
-    send_discord_webhook(command)
-    return jsonify({"status": f"Stop command for Bot {bot_id} sent via webhook"})
+    bot_manager.stop_bot(bot_id)
+    bots[bot_id - 1]["status"] = "Stopped"
+    send_discord_webhook(f"stop_bot {bot_id}")
+    return jsonify({"status": f"Bot {bot_id} stopped"})
 
 @app.route("/toggle_render", methods=["POST"])
 def toggle_render():
-    command = "toggle_render"
-    send_discord_webhook(command)
-    return jsonify({"status": "Toggle render command sent via webhook"})
+    bot_manager.toggle_render()
+    send_discord_webhook("toggle_render")
+    return jsonify({"status": "Toggled rendering on all bots"})
 
 @app.route("/set_server_ip", methods=["POST"])
 def set_server_ip():
     global server_ip
     new_ip = request.json.get("server_ip", server_ip)
     server_ip = new_ip  # update local dummy variable for display
-    command = f"set_server_ip {new_ip}"
-    send_discord_webhook(command)
-    return jsonify({"status": f"Server IP change command sent: {new_ip}"})
+    send_discord_webhook(f"set_server_ip {new_ip}")
+    return jsonify({"status": f"Server IP set to {new_ip}"})
 
 @app.route("/send_chat", methods=["POST"])
 def send_chat():
     chat_message = request.json.get("chat_message", "")
-    command = f"chat {chat_message}"
-    send_discord_webhook(command)
-    return jsonify({"status": "Chat command sent via webhook"})
+    bot_manager.broadcast_chat(chat_message)
+    send_discord_webhook(f"chat {chat_message}")
+    return jsonify({"status": "Chat message broadcast"})
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000, debug=True)

--- a/flask-dashboard/dummy_bot.py
+++ b/flask-dashboard/dummy_bot.py
@@ -1,0 +1,24 @@
+import argparse
+import sys
+import time
+
+parser = argparse.ArgumentParser(description="Dummy Minecraft bot")
+parser.add_argument("--bot_id", type=int, required=True)
+parser.add_argument("--server_ip", required=True)
+args = parser.parse_args()
+
+print(f"[Bot {args.bot_id}] Connected to {args.server_ip}")
+sys.stdout.flush()
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    if line == "stop":
+        print(f"[Bot {args.bot_id}] Stopping")
+        sys.stdout.flush()
+        break
+    else:
+        print(f"[Bot {args.bot_id}] Received command: {line}")
+        sys.stdout.flush()
+    time.sleep(0.1)


### PR DESCRIPTION
## Summary
- create `bot_manager.py` and `dummy_bot.py` to run example bot processes
- wire Flask dashboard to start/stop bots and send commands
- update README instructions for launching dashboard and note dummy bots

## Testing
- `python3 -m py_compile flask-dashboard/*.py`
- `python3 flask-dashboard/dummy_bot.py --bot_id 1 --server_ip test <<EOF
stop
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68401ec753d8832fb112d44bf5e5e122