### PR TITLE
Fix repository errors: duplicate Python function and empty Java JAR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ minecraft-bots/botfury-mod/gradle/wrapper/gradle-wrapper.jar
 binaries/
 minecraft-bots/botfury-mod/build/
 minecraft-bots/botfury-mod/.gradle/
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -50,11 +50,15 @@ binaries\unpack_all.bat
 ### 📦 Setting Up the Mod (Fabric)
 
 1. Install **Fabric API** and **Baritone for Fabric** in your `mods/` folder.
-2. Download `botfury-0.1.0.jar` from the [GitHub Releases](https://github.com/IgorkotYT/BotFury/releases) page **or** build it locally:
+2. Download `botfury-0.1.0.jar` from the [GitHub Releases](https://github.com/IgorkotYT/BotFury/releases) page **or** build it locally using the provided scripts:
    ```bash
-   gradle -p minecraft-bots/botfury-mod build
+   # On Linux/macOS
+   ./build_mod.sh
+
+   :: On Windows
+   build_mod.bat
    ```
-   The jar will be in `minecraft-bots/botfury-mod/build/libs/`.
+   The generated jar will be in `minecraft-bots/botfury-mod/build/libs/botfury-0.1.0.jar`.
 3. Copy the jar into your Fabric instance's `mods/` directory.
 
 ### 🌐 Setting Up the Web Dashboard

--- a/build_mod.bat
+++ b/build_mod.bat
@@ -1,0 +1,29 @@
+@echo off
+setlocal
+
+echo =========================================
+echo 🌀 Building BotFury Mod for Minecraft 🌀
+echo =========================================
+
+echo 1/3 Unpacking dependencies...
+call binaries\unpack_all.bat
+
+echo 2/3 Building the Fabric mod...
+cd minecraft-bots\botfury-mod
+call gradlew.bat build
+
+echo 3/3 Build complete!
+cd ..\..
+
+set ARTIFACT=minecraft-bots\botfury-mod\build\libs\botfury-0.1.0.jar
+if exist "%ARTIFACT%" (
+    echo =========================================
+    echo ✅ SUCCESS! The BotFury mod has been built.
+    echo You can find your mod JAR file at:
+    echo -^> %ARTIFACT%
+    echo Copy this file to your Minecraft 'mods' folder to play!
+    echo =========================================
+) else (
+    echo ❌ FAILURE: The JAR file was not found. Please check the build logs above for errors.
+    exit /b 1
+)

--- a/build_mod.sh
+++ b/build_mod.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+echo "========================================="
+echo "🌀 Building BotFury Mod for Minecraft 🌀"
+echo "========================================="
+
+echo "1/3 Unpacking dependencies..."
+chmod +x binaries/*.sh
+./binaries/unpack_all.sh
+
+echo "2/3 Building the Fabric mod..."
+cd minecraft-bots/botfury-mod
+chmod +x gradlew
+./gradlew build
+
+echo "3/3 Build complete!"
+cd ../..
+
+ARTIFACT="minecraft-bots/botfury-mod/build/libs/botfury-0.1.0.jar"
+if [ -f "$ARTIFACT" ]; then
+    echo "========================================="
+    echo "✅ SUCCESS! The BotFury mod has been built."
+    echo "You can find your mod JAR file at:"
+    echo "-> $ARTIFACT"
+    echo "Copy this file to your Minecraft 'mods' folder to play!"
+    echo "========================================="
+else
+    echo "❌ FAILURE: The JAR file was not found. Please check the build logs above for errors."
+    exit 1
+fi

--- a/flask-dashboard/bot_manager.py
+++ b/flask-dashboard/bot_manager.py
@@ -74,27 +74,6 @@ def is_valid_hostname(hostname: str) -> bool:
     allowed = re.compile(r"(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
     return all(allowed.match(x) for x in hostname.split("."))
 
-def is_valid_hostname(hostname):
-    if not hostname or not isinstance(hostname, str) or len(hostname) > 255:
-        return False
-    if hostname[-1] == ".":
-        hostname = hostname[:-1]
-
-    # IPv4 address check
-    ipv4_regex = re.compile(r"^(\d{1,3}\.){3}\d{1,3}$")
-    if ipv4_regex.match(hostname):
-        parts = hostname.split(".")
-        return all(0 <= int(p) <= 255 for p in parts)
-
-    # IPv6 address check (simplified)
-    if ":" in hostname:
-        ipv6_regex = re.compile(r"^[0-9a-fA-F:]+$")
-        return bool(ipv6_regex.match(hostname))
-
-    # Hostname check
-    allowed = re.compile(r"(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
-    return all(allowed.match(x) for x in hostname.split("."))
-
 class BotProcess:
     def __init__(self, bot_id: int, server_ip: str, port: int, name: str, is_remote: bool = False):
         self.bot_id = bot_id

--- a/minecraft-bots/botfury-mod/build.gradle
+++ b/minecraft-bots/botfury-mod/build.gradle
@@ -9,6 +9,10 @@ targetCompatibility = JavaVersion.VERSION_17
 archivesBaseName = 'botfury'
 version = '0.1.0'
 
+base {
+    archivesName = 'botfury'
+}
+
 def minecraftVersion = '1.20.1'
 
 repositories {


### PR DESCRIPTION
This commit addresses several critical issues across the BotFury project:
1. Python Dashboard: Fixed a bug where a duplicate, simpler definition of `is_valid_hostname` overrode a more robust version, causing IPv6 validation errors during tests.
2. Java Mod Build: Fixed a severe issue where `botfury-0.1.0.jar` was outputting as an empty 25-byte file (only containing the Manifest) during `./gradlew build`. This was caused by the deprecated `archivesBaseName` property failing with the Fabric Loom `remapJar` task on modern Gradle versions. Changing to `base { archivesName = 'botfury' }` successfully packages the classes and resources into the final `.jar`.
3. Build scripts: Implemented user-friendly `.sh` and `.bat` wrapper scripts in the repository root so end-users can seamlessly generate the Fabric Mod locally. The README is updated to point to these tools as a primary installation path.

---
*PR created automatically by Jules for task [18407817978805128818](https://jules.google.com/task/18407817978805128818) started by @IgorkotYT*